### PR TITLE
Try catch on filestyle since it doesn't have to exist

### DIFF
--- a/src/bootstrap-uploadprogress.js
+++ b/src/bootstrap-uploadprogress.js
@@ -167,9 +167,15 @@
             else{
                 new_form = $(html).find('form');
             }
+            
+            try{
+                // try and add filestyle if library exists
+                new_form.find(':file').filestyle({buttonBefore: true});
+            }
+            catch(error){
+                console.error(error)
+            }
 
-            // add the filestyle again
-            new_form.find(':file').filestyle({buttonBefore: true});
             this.$form.html(new_form.children());
         }
     };


### PR DESCRIPTION
This pull request resolves the issue that prevents the page from reloading after an error if filestyle does not exist. It will try and run filestyle if it fails it will log the error to the console and continue on.